### PR TITLE
separate DB credentials

### DIFF
--- a/server/controllers/[archived]event-ctrl.js
+++ b/server/controllers/[archived]event-ctrl.js
@@ -14,7 +14,7 @@ createEvent = (req, res) => {
     }
     // basic auth
     const credentials = auth(req)
-    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.DB_PASS)) {
+    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.PASS)) {
         return res.status(401).json({ success: false, error: "Access denied." })
     }
     // get model

--- a/server/controllers/candidate-ctrl.js
+++ b/server/controllers/candidate-ctrl.js
@@ -14,7 +14,7 @@ createCandidate = (req, res) => {
     }
     // basic auth
     const credentials = auth(req)
-    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.DB_PASS)) {
+    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.PASS)) {
         return res.status(401).json({ success: false, error: "Access denied." })
     }
     // get model
@@ -50,7 +50,7 @@ updateCandidate = async (req, res) => {
     }
     // basic auth
     const credentials = auth(req)
-    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.DB_PASS)) {
+    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.PASS)) {
         return res.status(401).json({ success: false, error: "Access denied." })
     }
 
@@ -92,7 +92,7 @@ updateCandidate = async (req, res) => {
 deleteCandidate = async (req, res) => {
     // basic auth
     const credentials = auth(req)
-    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.DB_PASS)) {
+    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.PASS)) {
         return res.status(401).json({ success: false, error: "Access denied." })
     }
     await Candidate.findOneAndDelete({ _id: req.params.id }, (err, candidate) => {

--- a/server/controllers/info-ctrl.js
+++ b/server/controllers/info-ctrl.js
@@ -14,7 +14,7 @@ createInfo = (req, res) => {
     }
     // basic auth
     const credentials = auth(req)
-    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.DB_PASS)) {
+    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.PASS)) {
         return res.status(401).json({ success: false, error: "Access denied." })
     }
     // apply model to get doc
@@ -91,7 +91,7 @@ updateInfo = async (req, res) => {
     }
     // basic auth
     const credentials = auth(req)
-    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.DB_PASS)) {
+    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.PASS)) {
         return res.status(401).json({ success: false, error: "Access denied." })
     }
 
@@ -148,7 +148,7 @@ updateInfo = async (req, res) => {
 deleteInfo = async (req, res) => {
     // basic auth
     const credentials = auth(req)
-    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.DB_PASS)) {
+    if (!credentials || !compare(credentials.name, process.env.USERNAME) || !compare(credentials.pass, process.env.PASS)) {
         return res.status(401).json({ success: false, error: "Access denied." })
     }
     // TODO: change the candidate.infos

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -2,7 +2,7 @@ require('dotenv').config()
 const mongoose = require('mongoose')
 
 mongoose
-    .connect(`mongodb+srv://${process.env.USERNAME}:${process.env.DB_PASS}@nucatgt.jfmfo.mongodb.net/${process.env.DB_NAME}?retryWrites=true&w=majority`, {
+    .connect(`mongodb+srv://${process.env.DB_USERNAME}:${process.env.DB_PASS}@${process.env.DB_ADDRESS}/${process.env.DB_NAME}?retryWrites=true&w=majority`, {
         useNewUrlParser: true,
         useUnifiedTopology: true,
         useFindAndModify: false


### PR DESCRIPTION
Separate the DB username/password from the server username/password.  This is a common security practice, to provide an extra layer of separation.

Allow the DB address to be specified in the ENV, so we can put the Madison mongodb server in there.

@ChujieChen 
Note: you'll need to modify your `.env` file a bit.