### PR TITLE
fix polygon - candidate takes 1st info's json

### DIFF
--- a/server/controllers/info-ctrl.js
+++ b/server/controllers/info-ctrl.js
@@ -49,6 +49,7 @@ createInfo = (req, res) => {
                 energy: i.energy,
                 type: i.type,
                 track: i.track,
+                json: i.json,
                 infos: [i.id],
             }
             console.log(cand)
@@ -57,6 +58,10 @@ createInfo = (req, res) => {
                     if (err) console.log(err);
                     if (!created) {
                         // if not created => candidate already exists
+                        // append new i.id to candidate.infos
+                        // keep everything else untouched
+                        // manually update everything else 
+                        // (the latest may not be the best)
                         Candidate.findOneAndUpdate(conditions, { '$push': { infos: i.id } })
                             .then(console.log("Successfully added one more info into existing candidate"));
                     } else {


### PR DESCRIPTION
It turns out we had the sufficient `candidate` model - there is always a `json` field. Now if the first `info` created with a `json`, the `candidate` will also have that `json`. However, if the `json` is not in the **first** `info` but in a later `info` related to this `candidate`, the `json` would not automatically go into that `candidate`. This works as planed - the latest `info` might not be the recommended `info`.

However, in the future, we might want to implement a quick way to update the `candidate`. We shall provide two ways to update one `candidate`: 1. overwrite the entire `candidate` (already implemented); 2. overlay the `candidate` with additional fields (TODO).